### PR TITLE
fix: gracefully handle missing wallpaper files during luminance calculations

### DIFF
--- a/src/TED/TED.Utils/ImageUtilities.cs
+++ b/src/TED/TED.Utils/ImageUtilities.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace TED.Utils
@@ -32,14 +33,14 @@ namespace TED.Utils
         /// <summary>
         /// Calculates the perceived luminance of the current desktop wallpaper.
         /// </summary>
-        /// <returns>A value representing the calculated perceived luminance of the wallpaper. Returns 0.0 if the wallpaper path is not found.</returns>
+        /// <returns>A value representing the calculated perceived luminance of the wallpaper. Returns 0.0 if the wallpaper path is not found or no longer exists.</returns>
         public static double CalculateWallpaperLuminance()
         {
             // Get the wallpaper path from the registry
             string wallpaperPath = SystemUtilities.GetWallpaperPathFromRegistry();
             double luminance = 0.0;
 
-            if (!string.IsNullOrEmpty(wallpaperPath))
+            if (!string.IsNullOrEmpty(wallpaperPath) && File.Exists(wallpaperPath))
             {
                 using (var bmp = new Bitmap(wallpaperPath))
                 {

--- a/src/TED/TED.csproj
+++ b/src/TED/TED.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>TED</RootNamespace>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Open</Configurations>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <InformationalVersion>Prerelease</InformationalVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/TED/app.manifest
+++ b/src/TED/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.0.0.0" name="MyApplication.app"/>
+  <assemblyIdentity version="2.0.1.0" name="TED.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">


### PR DESCRIPTION
There can be a situation where IrisService leaves registry keys pointing to a wallpaper file that no longer exists, causing a crash during luminance calculation because we expect that if the file didn't exist, the path would be blank. We now explicitly check if the file exists first, otherwise we fallback to a 0.0 luminance.